### PR TITLE
sshpasswd.sh: Turn all used variables for password checking into local variables.

### DIFF
--- a/etc/profile.d/sshpasswd.sh
+++ b/etc/profile.d/sshpasswd.sh
@@ -3,11 +3,11 @@ check_hash ()
    if ! id -u pi > /dev/null 2>&1 ; then return 0 ; fi
    if grep -q "^PasswordAuthentication\s*no" /etc/ssh/sshd_config ; then return 0 ; fi
    test -x /usr/bin/mkpasswd || return 0
-   SHADOW="$(sudo -n grep -E '^pi:' /etc/shadow 2>/dev/null)"
+   local SHADOW="$(sudo -n grep -E '^pi:' /etc/shadow 2>/dev/null)"
    test -n "${SHADOW}" || return 0
    if echo $SHADOW | grep -q "pi:!" ; then return 0 ; fi
-   SALT=$(echo "${SHADOW}" | sed -n 's/pi:\$6\$//;s/\$.*//p')
-   HASH=$(mkpasswd -msha-512 raspberry "$SALT")
+   local SALT=$(echo "${SHADOW}" | sed -n 's/pi:\$6\$//;s/\$.*//p')
+   local HASH=$(mkpasswd -msha-512 raspberry "$SALT")
    test -n "${HASH}" || return 0
 
    if echo "${SHADOW}" | grep -q "${HASH}"; then


### PR DESCRIPTION
With the update of raspberrypi-sys-mods now there are some entries from the protected `/etc/shadow` file freely accessible from your shell. Here is an example:

```
Debian GNU/Linux comes with ABSOLUTELY NO WARRANTY, to the extent
permitted by applicable law.
Last login: <LOGIN DATE> from <MY HOST>

SSH is enabled and the default password for the 'pi' user has not been changed.
This is a security risk - please login as the 'pi' user and type 'passwd' to set a new password.

pi@raspberrypi:~ $ echo $HASH
$6$bmk114TW$JAC935CBBWpE/jYtw62VhyxiAzYK9aYymm7c5zoyleAyPTPHHoGRnaBSE.HU8NKM0dEl8VLTurRWiqg1pVIHf/
pi@raspberrypi:~ $ echo $SHADOW
pi:$6$bmk114TW$JAC935CBBWpE/jYtw62VhyxiAzYK9aYymm7c5zoyleAyPTPHHoGRnaBSE.HU8NKM0dEl8VLTurRWiqg1pVIHf/:17067:0:99999:7:::
pi@raspberrypi:~ $ echo $SALT
bmk114TW
pi@raspberrypi:~ $
```

The `/etc/shadow` file is explicitly only readable for the superuser to prevent accidental leakage.

This fix changes all variables inside the sshpasswd script to be only local variables. In doing so, the variables no longer exist once you can control the shell. It has been proposed [here](https://github.com/RPi-Distro/raspberrypi-sys-mods/commit/af5efe98c56a0947614493e7ade4d36e4f840d55#commitcomment-20521840).